### PR TITLE
Updates to DC 4.0, bumps Scala versions.

### DIFF
--- a/scalaextension/.gitignore
+++ b/scalaextension/.gitignore
@@ -2,3 +2,4 @@
 /.cache
 /.classpath
 /.project
+/.settings/

--- a/scalaextension/pom.xml
+++ b/scalaextension/pom.xml
@@ -6,35 +6,36 @@
 	<version>0.0.1-SNAPSHOT</version>
 	<inceptionYear>2008</inceptionYear>
 	<properties>
-		<scala.version>2.9.2</scala.version>
+		<scala.version>2.11.4</scala.version>
 	</properties>
 	<dependencies>
 		<dependency>
 			<groupId>org.scala-lang</groupId>
 			<artifactId>scala-library</artifactId>
-			<version>2.9.2</version>
+			<version>${scala.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.scalatest</groupId>
-			<artifactId>scalatest_2.9.2</artifactId>
-			<version>1.8</version>
+			<artifactId>scalatest_2.11</artifactId>
+			<version>2.2.0</version>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.scala-lang</groupId>
 			<artifactId>scala-compiler</artifactId>
-			<version>2.9.2</version>
+			<version>${scala.version}</version>
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.eobjects.analyzerbeans</groupId>
-			<artifactId>AnalyzerBeans-core</artifactId>
-			<version>0.21</version>
+			<groupId>org.eobjects.datacleaner</groupId>
+			<artifactId>DataCleaner-engine-core</artifactId>
+			<version>4.0-RC5</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.scala-lang</groupId>
 			<artifactId>scala-compiler</artifactId>
-			<version>2.9.2</version>
+			<version>${scala.version}</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
@@ -55,6 +56,7 @@
 			<plugin>
 				<groupId>net.alchim31.maven</groupId>
 				<artifactId>scala-maven-plugin</artifactId>
+				<version>3.2.0</version>
 				<executions>
 					<execution>
 						<goals>

--- a/scalaextension/src/main/scala/com/hi/scalaextension/ScalaCodeTransformer.scala
+++ b/scalaextension/src/main/scala/com/hi/scalaextension/ScalaCodeTransformer.scala
@@ -1,23 +1,22 @@
 package com.hi.scalaextension
 
-import org.eobjects.analyzer.beans.api.Transformer
-import org.eobjects.analyzer.beans.api.TransformerBean
-import org.eobjects.analyzer.beans.api.Description
-import org.eobjects.analyzer.beans.api.Categorized
-import org.eobjects.analyzer.beans.categories.StringManipulationCategory
-import org.eobjects.analyzer.data.InputColumn
-import org.eobjects.analyzer.beans.api.Configured
-import org.eobjects.analyzer.beans.api.OutputColumns
-import org.eobjects.analyzer.data.InputRow
-import org.eobjects.analyzer.beans.categories.ScriptingCategory
-import org.eobjects.analyzer.beans.api.StringProperty
-import org.eobjects.analyzer.beans.api.Initialize
 import scala.collection.JavaConversions._
+import javax.inject.Named
+import org.datacleaner.api.InputColumn
+import org.datacleaner.api.StringProperty
+import org.datacleaner.api.OutputColumns
+import org.datacleaner.api.InputRow
+import org.datacleaner.api.Initialize
+import org.datacleaner.api.Categorized
+import org.datacleaner.api.Description
+import org.datacleaner.api.Configured
+import org.datacleaner.api.Transformer
+import org.datacleaner.components.categories.ScriptingCategory
 
-@TransformerBean("Scala Transformer")
+@Named("Scala Transformer")
 @Description("Supply your own piece of Scala code to do a custom transformation.")
 @Categorized(Array(classOf[ScriptingCategory]))
-class ScalaCodeTransformer(cols: Array[InputColumn[_]]) extends Transformer[java.lang.Object] {
+class ScalaCodeTransformer(cols: Array[InputColumn[_]]) extends Transformer {
 
   @Configured
   var columns: Array[InputColumn[_]] = cols;

--- a/scalaextension/src/test/scala/com/hi/scalaextension/ScalaCodeTransformerTest.scala
+++ b/scalaextension/src/test/scala/com/hi/scalaextension/ScalaCodeTransformerTest.scala
@@ -3,9 +3,9 @@ package com.hi.scalaextension
 import org.junit.Test
 import org.scalatest.junit.AssertionsForJUnit
 import org.scalatest.junit.JUnitSuite
-import org.eobjects.analyzer.data.MockInputColumn
 import org.junit.Assert._
-import org.eobjects.analyzer.data.MockInputRow
+import org.datacleaner.data.MockInputRow
+import org.datacleaner.data.MockInputColumn
 
 class ScalaCodeTransformerTest extends AssertionsForJUnit {
 


### PR DESCRIPTION
This will update the ScalaDataCleanerExtension to DataCleaner 4.0, as well as use the 2.11 version of Scala.
